### PR TITLE
fix: ignore cdktf documentation for registry limit

### DIFF
--- a/check/directory.go
+++ b/check/directory.go
@@ -112,7 +112,7 @@ func NumberOfFilesCheck(directories map[string][]string) error {
 	var numberOfFiles int
 
 	for directory, files := range directories {
-		// Ignore CDKTF files, they are not shown in the Terraform Registry Side-Bar and therefore do not count against the limit
+		// Ignore CDKTF files. The file limit is per-language and presumably there is one CDKTF file per source HCL file.
 		if IsValidCdktfDirectory(directory) {
 			continue
 		}

--- a/check/directory.go
+++ b/check/directory.go
@@ -112,6 +112,11 @@ func NumberOfFilesCheck(directories map[string][]string) error {
 	var numberOfFiles int
 
 	for directory, files := range directories {
+		// Ignore CDKTF files, they are not shown in the Terraform Registry Side-Bar and therefore do not count against the limit
+		if IsValidCdktfDirectory(directory) {
+			continue
+		}
+
 		directoryNumberOfFiles := len(files)
 		log.Printf("[TRACE] Found %d documentation files in directory: %s", directoryNumberOfFiles, directory)
 		numberOfFiles = numberOfFiles + directoryNumberOfFiles


### PR DESCRIPTION
See https://github.com/bflad/tfproviderdocs/pull/78 for reference