### PR TITLE
Include functions documentation directories in glob check

### DIFF
--- a/check/check_test.go
+++ b/check/check_test.go
@@ -41,6 +41,11 @@ func TestCheck(t *testing.T) {
 			ExpectError: true,
 		},
 		{
+			Name:        "invalid registry directories with functions",
+			BasePath:    "testdata/invalid-registry-directories-functions",
+			ExpectError: true,
+		},
+		{
 			Name:        "invalid legacy directories",
 			BasePath:    "testdata/invalid-legacy-directories",
 			ExpectError: true,

--- a/check/directory.go
+++ b/check/directory.go
@@ -10,7 +10,7 @@ import (
 const (
 	CdktfIndexDirectory = `cdktf`
 
-	DocumentationGlobPattern = `{docs/index.md,docs/{,cdktf/}{data-sources,ephemeral-resources,guides,resources},website/docs}/**/*`
+	DocumentationGlobPattern = `{docs/index.md,docs/{,cdktf/}{data-sources,ephemeral-resources,functions,guides,resources},website/docs}/**/*`
 
 	LegacyIndexDirectory       = `website/docs`
 	LegacyDataSourcesDirectory = `d`

--- a/check/testdata/invalid-registry-directories-functions/docs/functions/invalid/thing.md
+++ b/check/testdata/invalid-registry-directories-functions/docs/functions/invalid/thing.md
@@ -1,0 +1,1 @@
+# Invalid registry function doc


### PR DESCRIPTION
## Summary
- include the functions subdirectory (and its CDKTF variant) in the documentation glob pattern
- add a regression test that ensures invalid registry function directories are detected

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c9f188e40483319a4c0aa069edac76