### PR TITLE
Fix ignore file missing flag bindings

### DIFF
--- a/command/check.go
+++ b/command/check.go
@@ -115,11 +115,7 @@ Options:
 
 func (c *CheckCommand) Name() string { return "check" }
 
-func (c *CheckCommand) Run(args []string) int {
-	var config CheckCommandConfig
-
-	flags := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
-	flags.Usage = func() { c.Ui.Info(c.Help()) }
+func configureCheckCommandFlags(flags *flag.FlagSet, config *CheckCommandConfig) {
 	LogLevelFlag(flags, &config.LogLevel)
 	flags.StringVar(&config.AllowedGuideSubcategories, "allowed-guide-subcategories", "", "")
 	flags.StringVar(&config.AllowedGuideSubcategoriesFile, "allowed-guide-subcategories-file", "", "")
@@ -145,7 +141,7 @@ func (c *CheckCommand) Run(args []string) int {
 	flags.StringVar(&config.IgnoreFileMismatchFunctions, "ignore-file-mismatch-functions", "", "")
 	flags.StringVar(&config.IgnoreFileMismatchResources, "ignore-file-mismatch-resources", "", "")
 	flags.StringVar(&config.IgnoreFileMissingDataSources, "ignore-file-missing-data-sources", "", "")
-	flags.StringVar(&config.IgnoreFileMissingFunctions, "ignore-file-missing-ephemerals", "", "")
+	flags.StringVar(&config.IgnoreFileMissingEphemerals, "ignore-file-missing-ephemerals", "", "")
 	flags.StringVar(&config.IgnoreFileMissingFunctions, "ignore-file-missing-functions", "", "")
 	flags.StringVar(&config.IgnoreFileMissingResources, "ignore-file-missing-resources", "", "")
 	flags.StringVar(&config.ProviderName, "provider-name", "", "")
@@ -154,6 +150,14 @@ func (c *CheckCommand) Run(args []string) int {
 	flags.BoolVar(&config.RequireGuideSubcategory, "require-guide-subcategory", false, "")
 	flags.BoolVar(&config.RequireResourceSubcategory, "require-resource-subcategory", false, "")
 	flags.BoolVar(&config.RequireSchemaOrdering, "require-schema-ordering", false, "")
+}
+
+func (c *CheckCommand) Run(args []string) int {
+	var config CheckCommandConfig
+
+	flags := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+	flags.Usage = func() { c.Ui.Info(c.Help()) }
+	configureCheckCommandFlags(flags, &config)
 
 	if err := flags.Parse(args); err != nil {
 		flags.Usage()

--- a/command/check_test.go
+++ b/command/check_test.go
@@ -1,11 +1,41 @@
 package command
 
 import (
+	"flag"
 	"reflect"
 	"testing"
 
 	tfjson "github.com/hashicorp/terraform-json"
 )
+
+func TestConfigureCheckCommandFlagsIgnoreFileMissingBindings(t *testing.T) {
+	var config CheckCommandConfig
+	flags := flag.NewFlagSet("check", flag.ContinueOnError)
+
+	configureCheckCommandFlags(flags, &config)
+
+	const ephemeralValue = "example-ephemeral"
+	if err := flags.Set("ignore-file-missing-ephemerals", ephemeralValue); err != nil {
+		t.Fatalf("unexpected error setting ignore-file-missing-ephemerals flag: %s", err)
+	}
+
+	if got := config.IgnoreFileMissingEphemerals; got != ephemeralValue {
+		t.Fatalf("expected IgnoreFileMissingEphemerals to be %q, got %q", ephemeralValue, got)
+	}
+
+	if got := config.IgnoreFileMissingFunctions; got != "" {
+		t.Fatalf("expected IgnoreFileMissingFunctions to be empty before setting flag, got %q", got)
+	}
+
+	const functionsValue = "example-function"
+	if err := flags.Set("ignore-file-missing-functions", functionsValue); err != nil {
+		t.Fatalf("unexpected error setting ignore-file-missing-functions flag: %s", err)
+	}
+
+	if got := config.IgnoreFileMissingFunctions; got != functionsValue {
+		t.Fatalf("expected IgnoreFileMissingFunctions to be %q, got %q", functionsValue, got)
+	}
+}
 
 func TestAllowedSubcategoriesFile(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
## Summary
- ensure the `-ignore-file-missing-ephemerals` CLI flag populates the correct configuration field
- refactor check command flag registration into a helper shared by the command and tests
- add a unit test covering the ignore file missing ephemerals and functions flag bindings

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c9f2fb5f208331bb1cf942ded20afd