### PR TITLE
Updates Import section check to allow "For example:" on separate line

### DIFF
--- a/check/contents/check_import_section.go
+++ b/check/contents/check_import_section.go
@@ -76,7 +76,8 @@ func (d *Document) checkImportSection() error {
 		}
 
 		suffix := ". For example:"
-		if !strings.HasSuffix(text, suffix) && !strings.Contains(text, "cannot import") {
+		suffixNewline := ".\nFor example:"
+		if !strings.HasSuffix(text, suffix) && !strings.HasSuffix(text, suffixNewline) && !strings.Contains(text, "cannot import") {
 			return fmt.Errorf("import section should conclude with %q (or state \"You cannot import ...\")", suffix)
 		}
 	}

--- a/check/contents/check_import_section_test.go
+++ b/check/contents/check_import_section_test.go
@@ -42,6 +42,11 @@ func TestCheckImportSection(t *testing.T) {
 			ProviderName: "test",
 		},
 		{
+			Name:         "passing \"For example\" on new line",
+			Path:         "testdata/import/passing_for_example_on_newline.md",
+			ProviderName: "test",
+		},
+		{
 			Name:         "wrong code block resource type",
 			Path:         "testdata/import/wrong_code_block_resource_type.md",
 			ProviderName: "test",

--- a/check/contents/testdata/import/passing_for_example_on_newline.md
+++ b/check/contents/testdata/import/passing_for_example_on_newline.md
@@ -1,0 +1,18 @@
+<!-- Copyright IBM Corp. 2019, 2026 -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+## Import
+
+Import Passings using the `name`.
+For example:
+
+```terraform
+import {
+  to = test_passing_for_example_on_newline.example
+  id = "example"
+}
+```
+
+```console
+% terraform import test_passing_for_example_on_newline.example example
+```


### PR DESCRIPTION
Currently, the Import section check requires the phrase "For example:" to be on the same line as "Import <resource type> using <attribute>." This PR allows "For example:" to be on a separate line.